### PR TITLE
lib ownership has split to appEng

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*              @transferwise/central-sre
+*              @transferwise/application-engineering


### PR DESCRIPTION
## Context

causing confusion on dev portal.
We don't own this, leave only actual owners in

https://transferwise.atlassian.net/browse/SRE-1982
## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
